### PR TITLE
docs: remove Twitter references

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,12 +53,7 @@ Comrade needs your connection info in a config file. Create a file named `config
 
     {
       "mastodon_token": "Your Mastodon access token",
-      "mastodon_instance": "Base URL of your Mastodon instance, if not mastodon.social",
-
-      "api_key": "(deprecated) Your Twitter API key",
-      "api_secret": "(deprecated) Your Twitter API secret",
-      "access_token": "(deprecated) Your Twitter access token",
-      "access_secret": "(deprecated) Your Twitter access secret"
+      "mastodon_instance": "Base URL of your Mastodon instance, if not mastodon.social"
     }
 
 
@@ -71,4 +66,4 @@ Run a script with :code:`--help` for more info.
 post-media
 ~~~~~~~~~~
 
-Post images to Twitter and/or Mastodon (depending on what's in your config file)
+Post images to Mastodon using your configured access token


### PR DESCRIPTION
## Summary
- drop deprecated Twitter API keys from config docs
- update `post-media` description to only mention Mastodon

## Testing
- `python -m pip install -r docs/sphinx-requirements.txt` *(fails: Could not find a version that satisfies the requirement diskcache==5.6.3)*
- `make -C docs html` *(fails: sphinx-build: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f80143e8c8320a358647a6d6e458f