### PR TITLE
Allow multiple image attachments in post-media

### DIFF
--- a/comrade/scripts/post_media.py
+++ b/comrade/scripts/post_media.py
@@ -1,4 +1,4 @@
-﻿import time
+import time
 import json
 import mimetypes
 

--- a/comrade/scripts/post_media.py
+++ b/comrade/scripts/post_media.py
@@ -8,7 +8,13 @@ from mastodon import Mastodon
 
 @click.command()
 @click.option("--config", type=click.Path(dir_okay=False), required=True)
-@click.option("--image", type=click.Path(dir_okay=False), required=False)
+@click.option(
+    "--image",
+    type=click.Path(dir_okay=False),
+    multiple=True,
+    required=False,
+    help="Path to an image file. Use multiple --image options to attach multiple images.",
+)
 @click.option("--alt", type=str, required=False)
 @click.option("--status", type=str, required=True)
 @click.option("--in-reply-to", type=str)
@@ -23,14 +29,14 @@ from mastodon import Mastodon
 @click.option("--log-dir", type=click.Path(dir_okay=True), default=None)
 def main(
     config,
-    image,
+    image: tuple[str, ...],
     alt,
     status,
     in_reply_to=None,
     sensitive=False,
     cw=None,
     visibility="public",
-    log_dir=None
+    log_dir=None,
 ):
     cfg = json.load(open(config))
 
@@ -55,7 +61,7 @@ def main(
                 return response["id"]
 
             if image:
-                media_ids = [upload_media(item, alt) for item in image.split(",")]
+                media_ids = [upload_media(path, alt) for path in image]
             else:
                 media_ids = None
 

--- a/comrade/scripts/post_media.py
+++ b/comrade/scripts/post_media.py
@@ -1,4 +1,3 @@
-import time
 import json
 import mimetypes
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,12 +53,7 @@ Comrade needs your connection info in a config file. Create a file named `config
 
     {
       "mastodon_token": "Your Mastodon access token",
-      "mastodon_instance": "Base URL of your Mastodon instance, if not mastodon.social",
-
-      "api_key": "(deprecated) Your Twitter API key",
-      "api_secret": "(deprecated) Your Twitter API secret",
-      "access_token": "(deprecated) Your Twitter access token",
-      "access_secret": "(deprecated) Your Twitter access secret"
+      "mastodon_instance": "Base URL of your Mastodon instance, if not mastodon.social"
     }
 
 
@@ -71,5 +66,5 @@ Run a script with :code:`--help` for more info.
 post-media
 ~~~~~~~~~~
 
-Post images to Twitter and/or Mastodon (depending on what's in your config file).
+Post images to Mastodon using your configured access token.
 Use ``--image`` multiple times to attach several images to a single post.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,4 +71,5 @@ Run a script with :code:`--help` for more info.
 post-media
 ~~~~~~~~~~
 
-Post images to Twitter and/or Mastodon (depending on what's in your config file)
+Post images to Twitter and/or Mastodon (depending on what's in your config file).
+Use ``--image`` multiple times to attach several images to a single post.


### PR DESCRIPTION
## Summary
- support providing `--image` multiple times when posting media
- document multi-image usage

## Testing
- `pytest`
- `python -m py_compile comrade/scripts/post_media.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8015f318832096104aa9563be178