### PR TITLE
Ensure file handles are closed in posting script

### DIFF
--- a/comrade/scripts/post_media.py
+++ b/comrade/scripts/post_media.py
@@ -1,4 +1,3 @@
-﻿import time
 import json
 import mimetypes
 
@@ -32,7 +31,9 @@ def main(
     visibility="public",
     log_dir=None
 ):
-    cfg = json.load(open(config))
+    """Post a status with optional media to supported platforms."""
+    with open(config) as cfg_file:
+        cfg = json.load(cfg_file)
 
     if log_dir:
         logger.add(f"{log_dir}/comrade.log", retention="7 days")
@@ -46,12 +47,13 @@ def main(
 
             def upload_media(path, description):
                 mime_type = mimetypes.guess_type(path)[0]
-                response = mastodon.media_post(
-                    open(path, "rb"),
-                    mime_type,
-                    description=description,
-                    synchronous=True
-                )
+                with open(path, "rb") as media_file:
+                    response = mastodon.media_post(
+                        media_file,
+                        mime_type,
+                        description=description,
+                        synchronous=True,
+                    )
                 return response["id"]
 
             if image:

--- a/tests/test_post_media.py
+++ b/tests/test_post_media.py
@@ -1,0 +1,78 @@
+import json
+import builtins
+import sys
+import types
+from pathlib import Path
+
+from click.testing import CliRunner
+
+# Ensure the package root is importable when running tests directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide stub modules so `post_media` can be imported without optional
+# dependencies.
+class _DummyLogger:
+    def add(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+sys.modules.setdefault("loguru", types.SimpleNamespace(logger=_DummyLogger()))
+sys.modules.setdefault("mastodon", types.SimpleNamespace(Mastodon=object))
+
+from comrade.scripts import post_media
+from comrade.scripts.post_media import main
+
+
+def test_files_closed_after_run(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    config_file.write_text(
+        json.dumps({"mastodon_token": "t", "mastodon_instance": "https://example.com"})
+    )
+    image_file = tmp_path / "image.txt"
+    image_file.write_text("data")
+
+    close_counts = {"config": 0, "image": 0}
+    orig_open = builtins.open
+
+    def tracking_open(path, *args, **kwargs):
+        f = orig_open(path, *args, **kwargs)
+        tag = None
+        if path == str(config_file):
+            tag = "config"
+        elif path == str(image_file):
+            tag = "image"
+        if tag:
+            orig_close = f.close
+
+            def close():
+                close_counts[tag] += 1
+                return orig_close()
+
+            f.close = close
+        return f
+
+    monkeypatch.setattr(builtins, "open", tracking_open)
+
+    class DummyMastodon:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def media_post(self, fileobj, mime_type, description=None, synchronous=False):
+            assert not fileobj.closed
+            return {"id": "1"}
+
+        def status_post(self, *args, **kwargs):
+            return {}
+
+    monkeypatch.setattr(post_media, "Mastodon", DummyMastodon)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--config", str(config_file), "--image", str(image_file), "--status", "hello"],
+    )
+    assert result.exit_code == 0, result.output
+    assert close_counts["config"] == 1
+    assert close_counts["image"] == 1


### PR DESCRIPTION
## Summary
- use context managers when loading config and uploading media so files are closed
- add regression test confirming config and media files are closed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7f125d6083209d07097b7a185fbd